### PR TITLE
Fix crash upon breaking a block in SSP

### DIFF
--- a/src/main/java/ru/denull/BugPatch/mod/ClientEvents.java
+++ b/src/main/java/ru/denull/BugPatch/mod/ClientEvents.java
@@ -27,10 +27,11 @@ import org.apache.logging.log4j.Logger;
 public class ClientEvents {
 	public Logger logger = LogManager.getLogger("BugPatch");
 	
+
     @SubscribeEvent
     public void blockBreak(BlockEvent.BreakEvent evt) {
         PlayerControllerMP controller = Minecraft.getMinecraft().playerController;
-        Method m = ReflectionHelper.findMethod(PlayerControllerMP.class, controller, new String[] {"syncCurrentPlayItem", "func_78750_k", "k"});
+        Method m = ReflectionHelper.findMethod(PlayerControllerMP.class, controller, new String[] {"syncCurrentPlayItem", "func_78750_j", "k"});
         if (m != null) {
             try {
                 m.setAccessible(true);


### PR DESCRIPTION
Upon breaking any block in a single player world, the game would crash with this stacktrace:

```
Description: Ticking memory connection

cpw.mods.fml.relauncher.ReflectionHelper$UnableToFindMethodException: java.lang.NoSuchMethodException: net.minecraft.client.multiplayer.PlayerControllerMP.k()
	at cpw.mods.fml.relauncher.ReflectionHelper.findMethod(ReflectionHelper.java:187)
	at ru.denull.BugPatch.mod.ClientEvents.blockBreak(ClientEvents.java:33)
	at cpw.mods.fml.common.eventhandler.ASMEventHandler_59_ClientEvents_blockBreak_BreakEvent.invoke(.dynamic)
	at cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54)
	at cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140)
	at net.minecraftforge.common.ForgeHooks.onBlockBreakEvent(ForgeHooks.java:467)
	at net.minecraft.server.management.ItemInWorldManager.func_73084_b(ItemInWorldManager.java:259)
	at net.minecraft.server.management.ItemInWorldManager.func_73074_a(ItemInWorldManager.java:151)
	at net.minecraft.network.NetHandlerPlayServer.func_147345_a(NetHandlerPlayServer.java:489)
	at net.minecraft.network.play.client.C07PacketPlayerDigging.func_148833_a(SourceFile:53)
	at net.minecraft.network.play.client.C07PacketPlayerDigging.func_148833_a(SourceFile:8)
	at net.minecraft.network.NetworkManager.func_74428_b(NetworkManager.java:212)
	at net.minecraft.network.NetworkSystem.func_151269_c(NetworkSystem.java:165)
	at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:659)
	at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:547)
	at net.minecraft.server.integrated.IntegratedServer.func_71217_p(IntegratedServer.java:111)
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:396)
	at net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685)
Caused by: java.lang.NoSuchMethodException: net.minecraft.client.multiplayer.PlayerControllerMP.k()
	at java.lang.Class.getDeclaredMethod(Class.java:2130)
	at cpw.mods.fml.relauncher.ReflectionHelper.findMethod(ReflectionHelper.java:178)
... 17 more
```

This commit fixes the crash by changing the SRG name of the wanted function to `func_78750_j` from `func_78750_k`. The latter does not exist.